### PR TITLE
Missing dlls

### DIFF
--- a/AShortHike.Randomizer/Main.cs
+++ b/AShortHike.Randomizer/Main.cs
@@ -1,5 +1,8 @@
 ﻿using BepInEx;
 using HarmonyLib;
+using System;
+using System.IO;
+using System.Reflection;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
@@ -16,6 +19,7 @@ namespace AShortHike.Randomizer
 
         private void Awake()
         {
+            AppDomain.CurrentDomain.AssemblyResolve += new ResolveEventHandler(LoadMissingAssemblies);
             _instance ??= this;
             Randomizer = new Randomizer();
 
@@ -47,5 +51,12 @@ namespace AShortHike.Randomizer
         public static void LogWarning(object message) => _instance.Logger.LogWarning(message);
 
         public static void LogError(object message) => _instance.Logger.LogError(message);
+
+        private Assembly LoadMissingAssemblies(object send, ResolveEventArgs args)
+        {
+            string assemblyPath = Path.GetFullPath($"Modding\\data\\{args.Name.Substring(0, args.Name.IndexOf(","))}.dll");
+            LogWarning("Loading missing assembly from " + assemblyPath);
+            return File.Exists(assemblyPath) ? Assembly.LoadFrom(assemblyPath) : null;
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # A Short Hike Randomizer
 
-To create a new short hike mod:
-
-```dotnet new bepinex5plugin -n ExampleMod -T netstandard2.0 -U 2019.4.29```
+### Installation
+1. Download and install the modding tools from https://github.com/BrandenEK/AShortHike.ModdingTools.
+1. Download the 'Randomizer.zip' from the [Releases](https://github.com/BrandenEK/AShortHike.Randomizer/releases) page, and then extract it into the modding folder.


### PR DESCRIPTION
When a mod needs to add its own referenced dlls, it will load them from the data folder