### PR TITLE
Prevent camera failing on outlook point

### DIFF
--- a/AShortHike.Randomizer/GeneralPatches.cs
+++ b/AShortHike.Randomizer/GeneralPatches.cs
@@ -1,7 +1,11 @@
 ﻿using HarmonyLib;
+using UnityEngine;
 
 namespace AShortHike.Randomizer
 {
+    /// <summary>
+    /// Display the key and value whenever something is being saved
+    /// </summary>
     [HarmonyPatch(typeof(Tags), nameof(Tags.SetBool))]
     class Tags_SaveBool_Patch
     {
@@ -10,7 +14,6 @@ namespace AShortHike.Randomizer
             Main.Log($"Saving bool: {tag} ({value})");
         }
     }
-
     [HarmonyPatch(typeof(Tags), nameof(Tags.SetInt))]
     class Tags_SaveInt_Patch
     {
@@ -19,7 +22,6 @@ namespace AShortHike.Randomizer
             Main.Log($"Saving int: {tag} ({num})");
         }
     }
-
     [HarmonyPatch(typeof(Tags), nameof(Tags.SetString))]
     class Tags_SaveString_Patch
     {
@@ -28,7 +30,6 @@ namespace AShortHike.Randomizer
             Main.Log($"Saving string: {tag} ({value})");
         }
     }
-
     [HarmonyPatch(typeof(Tags), nameof(Tags.SetFloat))]
     class Tags_SaveFloat_Patch
     {
@@ -38,4 +39,25 @@ namespace AShortHike.Randomizer
         }
     }
 
+    /// <summary>
+    /// Sometimes the camera on outlook point throws an error and stops updating, so check for null renderers
+    /// </summary>
+    [HarmonyPatch(typeof(CustomCullZone), "UpdateRenderers")]
+    class Camera_Update_Patch
+    {
+        public static bool Prefix(CustomCullZone __instance, bool show, ref bool ___shown)
+        {
+            if (show == ___shown)
+                return false;
+
+            foreach (Renderer r in __instance.renderers)
+            {
+                if (r != null)
+                    r.enabled = show;
+            }
+
+            ___shown = show;
+            return false;
+        }
+    }
 }


### PR DESCRIPTION
Because the chest on outlook point was destroyed and replaced, the camera zone had a null renderer which was causing problems.  This patches the camera update method and checks for null renderers