### PR TITLE
Add Modding API Link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,4 +11,4 @@
 
 ## Installation
 This mod is available for download through the [Short Hike Mod Installer](https://github.com/BrandenEK/AShortHike.Modding.Installer)
-- Required dependencies: Modding API
+- Required dependencies: [Modding API](https://github.com/BrandenEK/AShortHike.ModdingAPI)


### PR DESCRIPTION
This dependency step is easily overlooked by new non-windows users, especially when coming straight from AP. I knew it existed and couldn't remember where I found it at previously, hence the link.